### PR TITLE
feat: Add home page header

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Color App</title>
+    
+    <!-- WATER BRUSH FONT LINK-->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Water+Brush&display=swap" rel="stylesheet">
+
+    <title>Color Inspo</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,7 @@
+export default function Header() {
+    return (
+        <header className="grid place-content-center max-w-[981px] h-[220px] lg:h-60 border-[12px] rounded-[10px]">
+            <h1 className="font-water-brush text-5xl lg:text-9xl">Color Inspo</h1>
+        </header>
+    )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,9 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        'water-brush': '"Water Brush", cursive'
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
Closes #33 

This pull request adds a header component meant for the homepage.

- Includes the header and title elements.
- It follows the layout specified in the Figma design.
- The Google Font "Water Brush" was embedded into the application and used to style the title.
- Note: Colors have not been added yet and will be addressed later.

Please review the code and provide feedback. Any suggestions for improvements are welcome. 
