### PR TITLE
feature/issue-28/color context hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,8 @@
+import { useContext } from 'react';
+
 import { Button } from './components/ui/button';
-import { useColorGenerator } from './hooks';
+import { ColorContext } from './contexts/ColorContext';
+import { ColorContextValue } from './types';
 import {
   createBasicColorPrompt,
   createGuidedColorPrompt,
@@ -19,7 +22,9 @@ const GUIDED = createGuidedColorPrompt({
 });
 
 export default function App() {
-  const { colors, loading, error, updatePrompt } = useColorGenerator();
+  const { colors, loading, error, updatePrompt } = useContext(
+    ColorContext,
+  ) as ColorContextValue;
 
   function handleClick() {
     updatePrompt(GUIDED);

--- a/src/contexts/ColorContext.tsx
+++ b/src/contexts/ColorContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, useEffect, useState } from 'react';
+
+import useColorGenerator from '@/hooks/useColorGenerator';
+import { ColorContextProviderProps, ColorContextValue, HEX } from '@/types';
+
+export const ColorContext = createContext<ColorContextValue | null>(null);
+
+export default function ColorContextProvider({
+  children,
+}: ColorContextProviderProps): JSX.Element {
+  // checks if the preferred browser theme is dark
+  const isBrowserPreferenceDark: MediaQueryList = window.matchMedia(
+    '(prefers-color-scheme: dark)',
+  );
+
+  const [theme, setTheme] = useState<'light' | 'dark'>(
+    isBrowserPreferenceDark.matches ? 'dark' : 'light',
+  );
+
+  const [accentColor, setAccentColor] = useState<HEX | null>(null);
+
+  const { colors, loading, error, updatePrompt } = useColorGenerator();
+
+  useEffect(() => {
+    setAccentColor(colors.length > 0 ? colors[2] : null);
+  }, [colors]);
+
+  function handleThemeChange(event: MediaQueryListEvent): void {
+    setTheme(event.matches ? 'dark' : 'light');
+  }
+
+  useEffect(() => {
+    isBrowserPreferenceDark.addEventListener('change', handleThemeChange);
+    return () => {
+      isBrowserPreferenceDark.removeEventListener('change', handleThemeChange);
+    };
+  }, []);
+
+  return (
+    <ColorContext.Provider
+      value={{
+        theme,
+        accentColor,
+        setTheme,
+        error,
+        updatePrompt,
+        loading,
+        colors,
+      }}
+    >
+      {children}
+    </ColorContext.Provider>
+  );
+}

--- a/src/routes/Root/index.tsx
+++ b/src/routes/Root/index.tsx
@@ -2,16 +2,19 @@ import { Outlet } from 'react-router-dom';
 
 import Footer from '@/components/footer';
 import Header from '@/components/header';
+import ColorContextProvider from '@/contexts/ColorContext';
 
 const Root = () => {
   return (
-    <div className="container">
-      <Header />
-      <main className="p-20 space-y-8">
-        <Outlet />
-      </main>
-      <Footer />
-    </div>
+    <ColorContextProvider>
+      <div className="container">
+        <Header />
+        <main className="p-20 space-y-8">
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </ColorContextProvider>
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,3 +12,17 @@ export interface GuidedColorPrompt extends BasicColorPrompt {
   mood: string;
   keywords: Keyword[];
 }
+
+export interface ColorContextValue {
+  theme: 'light' | 'dark';
+  setTheme: React.Dispatch<React.SetStateAction<'light' | 'dark'>>;
+  colors: HEX[];
+  accentColor: HEX | null;
+  updatePrompt: (prompt: string | null) => void;
+  loading: boolean;
+  error: Error | null;
+}
+
+export interface ColorContextProviderProps {
+  children: React.ReactNode;
+}


### PR DESCRIPTION
This pull request adds a color context provider to be used across the app.

**Note**: I am not ready to merge yet, I still need some clarifications.

## This is what I have done so far

- [x] Created the react context hook that consumes the colors array from the `useColorGenerator` hook.
- [x] Wrapped child components of the root element with the `ColorContext` provider so they can access its value.
- [x] Removed the `useColorGenerator` hook from `App.tsx` entirely and used the `ColorContext` to provide the values needed for generating the color palette.
- [x] Set the app's theme to light or dark based on the user's browser preference.
- [x] Added an event listener that watches for changes in the user's preferred theme and sets the app's theme accordingly.
- [x] Set the accent color when there is a change in the colors array provided by the `useColorGenerator` hook

## Uncertainties

- [ ] How many accent colors the `ColorContext` is supposed to provide. In the acceptance criteria, only the 3rd in the colors array was specified, and the `ColorContext` provides just that
- [ ] How to link the colors from the light/dark theme into the application. Am I to style the application based on the theme?

Please take a look at the code. I will appreciate any feedback I get 😬